### PR TITLE
bugfix config for No signature of method: groovy.util.ConfigObject.mu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ nextflow run ./main.nf \
 ```
 
 Replace {your_nf-core_profile} with the profile for your organisation, e.g. `crick`. For more information on nf-core profiles, see the [list of available nf-core configs](https://github.com/nf-core/configs) plus other advice on pipeline configuration [here](https://nf-co.re/usage/configuration#profiles).
+
+# Outputs
+
+
+# Credits
+Spatial PHLEX is primarily developed by [Alastair Magness](mailto:alastair.magness@crick.ac.uk) at [The Francis Crick Institute](https://www.crick.ac.uk). Other core contributors include [Emma Colliver](mailto:emma.colliver@crick.ac.uk), [Mihaela Angelova](mailto:mihaela.angelova@crick.ac.uk), and [Katey Enfield](katey.enfield@crick.ac.uk).

--- a/conf/base.config
+++ b/conf/base.config
@@ -48,7 +48,7 @@ process {
   }
   withName:GRAPH_BARRIER {
     container = 'magnesa/phlex:deepimcyto_4'
-    time = { check_max( 1.5h * task.attempt, 'time' ) }
+    time = { check_max( 1.5.h * task.attempt, 'time' ) }
   }
   withName:NN_BARRIER {
     container = 'magnesa/phlex:deepimcyto_4'

--- a/run_Spatial-PHLEX.sh
+++ b/run_Spatial-PHLEX.sh
@@ -26,9 +26,9 @@ nextflow run ./main.nf \
     --barrier_cell_type "aSMA+ cells"\
     --n_neighbours 10\
     --outdir "../results" \
-    --release 'PHLEX_testing_170823_config_update' \
+    --release 'PHLEX_testing' \
     --singularity_bind_path '/camp,/nemo'\
     --plot_palette "$PWD/assets/PHLEX_test_palette.json" \
     -w "/camp/project/proj-tracerx-lung/txscratch/rubicon/deep_imcyto/work"\
     -profile crick \
-    # -resume
+    -resume


### PR DESCRIPTION
…ltiply() is applicable for argument types: (Integer) values: [1] error. Error caused by missing '.' in graph_barrier process config